### PR TITLE
fix(automation): fix automation script fails to run semantic-release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ node('mac') {
         stage('Release') {
             withCredentials([usernamePassword(credentialsId: '34dc9a59-1608-4470-9860-bd19030cadbb', passwordVariable: 'GH_TOKEN', usernameVariable: 'JENKINS_USER')]) {
                 withCredentials([usernamePassword(credentialsId: 'sdk-npm-token', passwordVariable: 'NPM_TOKEN', usernameVariable: 'NPM_USER')]) {
-                    sh 'npm run semantic-release || true'
+                    sh 'npm run release || true'
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "node node_modules/react-native/local-cli/cli.js start",
-    "test": "jest"
+    "test": "jest",
+    "release" : "cd usabilla-react-native && npm run semantic-release"
   },
   "dependencies": {
     "react": "16.2.0",


### PR DESCRIPTION
After merging the first automation script, it turns out it couldn't run semantic-release from the root directory of the project.
In this fix, i enter the subfolder containing the package and run semantic-release.