### PR TITLE
feat(campaigns): Add support for campaigns in iOS.

### DIFF
--- a/usabilla-react-native/ios/ReactNativeUsabilla/ReactNativeUsabilla.m
+++ b/usabilla-react-native/ios/ReactNativeUsabilla/ReactNativeUsabilla.m
@@ -41,6 +41,19 @@ RCT_EXPORT_METHOD(initialize:(NSString *)appID)
     [self.usabillaInterface initialize:appID];
 }
 
+RCT_EXPORT_METHOD(sendEvent:(NSString *)event)
+{
+    [self.usabillaInterface sendEvent:event];
+}
+
+RCT_EXPORT_METHOD(resetCampaignData:(RCTResponseSenderBlock)callback)
+{
+    [self.usabillaInterface resetCampaignData:^{
+        NSDictionary* resultsDict = @{@"success" : @YES};
+        callback(@[[NSNull null], resultsDict]);
+    }];
+}
+
 RCT_EXPORT_METHOD(showLoadedFrom)
 {
     UIViewController *rootController = (UIViewController *)[[[[UIApplication sharedApplication] delegate] window] rootViewController];

--- a/usabilla-react-native/ios/ReactNativeUsabilla/UsabillaInterface.swift
+++ b/usabilla-react-native/ios/ReactNativeUsabilla/UsabillaInterface.swift
@@ -45,8 +45,22 @@ class UsabillaInterface: NSObject {
 
     @objc(initialize:)
     func initialize(appID: String) {
-        Usabilla.initialize(appID: nil)
+        Usabilla.initialize(appID: appID)
         Usabilla.debugEnabled = true
+    }
+
+    @objc(sendEvent:)
+    func sendEvent(eventName: String) {
+        Usabilla.sendEvent(event: eventName)
+    }
+    
+    @objc(resetCampaignData:)
+    func resetCampaignData(completion: (() -> Swift.Void)?) {
+        Usabilla.resetCampaignData {
+            if let completion = completion {
+                completion()
+            }
+        }
     }
 }
 

--- a/usabilla-react-native/src/index.js
+++ b/usabilla-react-native/src/index.js
@@ -3,7 +3,7 @@ import { NativeEventEmitter, NativeModules, Platform, DeviceEventEmitter } from 
 let {UsabillaBridge} = NativeModules
 const usabillaEventEmitter = (Platform.OS == 'android') ? DeviceEventEmitter : new NativeEventEmitter(UsabillaBridge)
 
-/* Usabilla Sdk Functions */
+/* Usabilla SDK Functions */
 function initialize(appId) {
     if (Platform.OS == 'android') {
         usabillaEventEmitter.addListener(
@@ -16,6 +16,26 @@ function initialize(appId) {
 
 function loadFeedbackForm(formId) {
     UsabillaBridge.loadFeedbackForm(formId)
+}
+
+function sendEvent(event) {
+    UsabillaBridge.sendEvent(event)
+}
+
+function resetCampaignData(callback) {
+    if (callback) {
+        if (Platform.OS == 'ios') {
+            UsabillaBridge.resetCampaignData(callback)
+            return
+        }
+
+        console.warn("reset callback is only available iOS now")
+        return
+    }
+
+    UsabillaBridge.resetCampaignData(()=> {
+        console.log("campaign data is reset successfully")
+    })
 }
 
 function showLoadedForm(event) {
@@ -40,6 +60,8 @@ module.exports = {
     initialize,
     loadFeedbackForm,
     showLoadedForm,
+    sendEvent,
+    resetCampaignData,
     setFormDidLoadSuccessfully,
     setFormDidFailLoading,
     setFormDidClose


### PR DESCRIPTION
This PR adds support for campaigns in the iOS bridge.
Added methods :
    - sendEvent : allows sending an event to trigger a campaign
    - resetCampaignData : allows dropping previously saved and cached data related to camapaigns.
