### PR TITLE
fix(android): sample app crashing on startup

### DIFF
--- a/UsabillaSampleApp/android/app/build.gradle
+++ b/UsabillaSampleApp/android/app/build.gradle
@@ -73,7 +73,8 @@ import com.android.build.OutputFile
  */
 
 project.ext.react = [
-    entryFile: "index.js"
+    entryFile: "index.js",
+    enableHermes: false
 ]
 
 apply from: "../../node_modules/react-native/react.gradle"
@@ -140,6 +141,18 @@ dependencies {
     implementation project(':usabilla-react-native')
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation "com.facebook.react:react-native:0.+"  // From node_modules
+
+    def jscFlavor = 'org.webkit:android-jsc:+'
+
+    def enableHermes = project.ext.react.get("enableHermes", false);
+
+    if (enableHermes) {
+        def hermesPath = "../../node_modules/hermesvm/android/";
+        debugImplementation files(hermesPath + "hermes-debug.aar")
+        releaseImplementation files(hermesPath + "hermes-release.aar")
+    } else {
+        implementation jscFlavor
+    }
 }
 
 // Run this once to be able to run the application with BUCK

--- a/UsabillaSampleApp/android/build.gradle
+++ b/UsabillaSampleApp/android/build.gradle
@@ -28,6 +28,9 @@ allprojects {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
         }
+        maven {
+            url "$rootDir/../node_modules/jsc-android/dist"
+        }
         google()
     }
 }


### PR DESCRIPTION
This PR fixes the sample app crashing on startup.

The `libhermes.so` which causes the crash is introduced by the update of react native 0.60.5