### PR TITLE
[android] Use ReactApplicationContext when it is possible

### DIFF
--- a/UsabillaSampleApp/android/gradle/wrapper/gradle-wrapper.properties
+++ b/UsabillaSampleApp/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-bin.zip
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2-all.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/UsabillaSampleApp/package.json
+++ b/UsabillaSampleApp/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "react": "16.13.1",
     "react-native": "0.64.1",
-    "usabilla-react-native": "^0.12.0"
+    "usabilla-react-native": "file:../"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",

--- a/UsabillaSampleApp/yarn.lock
+++ b/UsabillaSampleApp/yarn.lock
@@ -6654,10 +6654,8 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-usabilla-react-native@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/usabilla-react-native/-/usabilla-react-native-0.12.0.tgz#b9de60e76e9495b630f0a143f0809b2cf292b9b4"
-  integrity sha512-Hs/9MuMTBOxLNcILOA5CUCvE8+razFqGUMljUXFrVmkUrA8Ch7ZAelRl67QQYSjoiOszLGqe984kEP3w5CxwnQ==
+"usabilla-react-native@file:..":
+  version "0.8.4"
 
 use-subscription@^1.0.0:
   version "1.4.1"

--- a/android/src/main/java/com/usabilla/reactnative/ubform/UsabillaBridge.java
+++ b/android/src/main/java/com/usabilla/reactnative/ubform/UsabillaBridge.java
@@ -128,13 +128,7 @@ public class UsabillaBridge extends ReactContextBaseJavaModule implements Usabil
      */
     @ReactMethod
     public void initialize(@NonNull String appId) {
-        final Activity activity = getCurrentActivity();
-        if (activity != null) {
-            usabilla.initialize(activity.getBaseContext(), appId);
-            usabilla.updateFragmentManager(((FragmentActivity) activity).getSupportFragmentManager());
-            return;
-        }
-        Log.e(LOG_TAG, "Initialisation not possible. Android activity is null");
+        usabilla.initialize(getReactApplicationContext());
     }
 
     /**
@@ -220,12 +214,7 @@ public class UsabillaBridge extends ReactContextBaseJavaModule implements Usabil
      */
     @ReactMethod
     public void resetCampaignData() {
-        final Activity activity = getCurrentActivity();
-        if (activity != null) {
-            usabilla.resetCampaignData(activity.getBaseContext());
-            return;
-        }
-        Log.e(LOG_TAG, "Resetting Usabilla campaigns is not possible. Android activity is null");
+        usabilla.resetCampaignData(getReactApplicationContext());
     }
 
     /**
@@ -233,12 +222,7 @@ public class UsabillaBridge extends ReactContextBaseJavaModule implements Usabil
      */
     @ReactMethod
     public void sendEvent(@NonNull final String eventName) {
-        final Activity activity = getCurrentActivity();
-        if (activity != null) {
-            usabilla.sendEvent(activity.getBaseContext(), eventName);
-            return;
-        }
-        Log.e(LOG_TAG, "Sending event to Usabilla is not possible. Android activity is null");
+        usabilla.sendEvent(getReactApplicationContext(), eventName);
     }
 
     /**
@@ -246,12 +230,7 @@ public class UsabillaBridge extends ReactContextBaseJavaModule implements Usabil
      */
     @ReactMethod
     public boolean dismiss() {
-        final Activity activity = getCurrentActivity();
-        if (activity != null) {
-            return usabilla.dismiss(activity.getBaseContext());
-        }
-        Log.e(LOG_TAG, "Dismissing the Usabilla form is not possible. Android activity is null");
-        return false;
+        return usabilla.dismiss(getReactApplicationContext());
     }
 
     /**
@@ -283,6 +262,11 @@ public class UsabillaBridge extends ReactContextBaseJavaModule implements Usabil
     public void onHostResume() {
         LocalBroadcastManager.getInstance(getReactApplicationContext()).registerReceiver(closingFormReceiver, new IntentFilter(UbConstants.INTENT_CLOSE_FORM));
         LocalBroadcastManager.getInstance(getReactApplicationContext()).registerReceiver(closingCampaignReceiver, new IntentFilter(UbConstants.INTENT_CLOSE_CAMPAIGN));
+
+        final Activity activity = getCurrentActivity();
+        if (activity instanceof FragmentActivity) {
+            usabilla.updateFragmentManager(((FragmentActivity) activity).getSupportFragmentManager());
+        }
     }
 
     @Override


### PR DESCRIPTION
Currently the bridge heavily uses React Activity to find the context.
However since both the bridge and Usabilla are application level objects, it seems it is not necessary to be so.
Commenting in each place for further explanations.
