### PR TITLE
fix(ios): Update podspec to support host arc

### DIFF
--- a/usabilla-react-native.podspec
+++ b/usabilla-react-native.podspec
@@ -18,7 +18,4 @@ Pod::Spec.new do |s|
 
   s.dependency 'React'
   s.dependency 'Usabilla', '~> 6.5'
-  
-  s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
-  s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end


### PR DESCRIPTION
Closes: [GFPSDK-1154](https://momentiveai.atlassian.net/browse/GFPSDK-1154)

Reviewers: @usabilla/bliss

### Changelog:
- Remove exclude arm64 podspec config to support current Host Architecture #193 